### PR TITLE
update bazel image to version 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 LABEL name="Bazel Action"
 LABEL maintainer="Nikita Galaiko"
-LABEL version="0.29.0"
+LABEL version="1.0.0"
 LABEL repository="https://github.com/ngalaiko/bazel-action"
 
 LABEL com.github.actions.name="Bazel Action"
@@ -10,8 +10,8 @@ LABEL com.github.actions.description="Run Bazel commands"
 LABEL com.github.actions.icon="box"
 LABEL com.github.actions.color="green"
 
-ENV BAZEL_VERSION=0.29.0
-ENV BAZEL_SHA256SUM=509c9ed0ee197a0cc613b187f00810d35c5d8716dbfe574616b3e1206d8ea01f
+ENV BAZEL_VERSION=1.0.0
+ENV BAZEL_SHA256SUM=4333d15cce4201646501fd1e895bc176995668384fb7b3a5053027269c9f3bdd
 
 RUN apt-get update && apt-get install -y \
         g++ \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ job:
     - uses: actions/checkout@master
 
     - name: run
-      uses: ngalaiko/bazel-action@0.29.0
+      uses: ngalaiko/bazel-action@1.0.0
       with:
         args: build //...
 ```


### PR DESCRIPTION
Hey,

I'm just starting to learn about GitHub actions and found this package really helpful. I noticed that Bazel recently released [version 1.0.0](https://github.com/bazelbuild/bazel/releases/tag/1.0.0) so I thought it might be helpful to raise a PR with an update.