### PR TITLE
Update OpenJDK to version 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:11
 
 LABEL name="Bazel Action"
 LABEL maintainer="Nikita Galaiko"


### PR DESCRIPTION
[Bazel supports OpenJDK 11](https://docs.bazel.build/versions/master/install-ubuntu.html). This PR updates the Docker image to use that as the base.