### PR TITLE
Bazel 1.1.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,11 @@ jobs:
         version:
         - 0.29.0
         - 1.0.0
-    
+        - 1.1.0
+
     steps:
     - uses: actions/checkout@v1
-    
+
     - name: build
       run: |
         docker build \

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,10 +13,11 @@ jobs:
         version:
         - 0.29.0
         - 1.0.0
-    
+        - 1.1.0
+
     steps:
     - uses: actions/checkout@v1
-    
+
     - name: build
       run: |
         docker build \

--- a/1.1.0/Dockerfile
+++ b/1.1.0/Dockerfile
@@ -1,0 +1,11 @@
+FROM ngalayko/bazel-action:1.1.0
+
+LABEL name="Bazel Action"
+LABEL maintainer="Nikita Galaiko"
+LABEL version="1.1.0"
+LABEL repository="https://github.com/ngalaiko/bazel-action"
+
+LABEL com.github.actions.name="Bazel Action"
+LABEL com.github.actions.description="Run Bazel commands"
+LABEL com.github.actions.icon="box"
+LABEL com.github.actions.color="green"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11
 
-ARG BAZEL_VERSION=0.29.0
+ARG BAZEL_VERSION=1.1.0
 
 RUN apt-get update && apt-get install -y \
         g++ \

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ uses: ngalaiko/bazel-action/0.29.0@master
 
 If you need another version, please open an issue, or send a PR.
 
-## GitHub actios
+## GitHub actions
 
 You can read more about GitHub actions in the [documentation](https://help.github.com/en/categories/automating-your-workflow-with-github-actions).


### PR DESCRIPTION
I hope this saves you some time putting a release with Bazel 1.1.0 together.

* Add an image for Bazel v1.1.0
* Fix a small typo in the README
* Update base image so you can quickly build and publish the v1.1.0 container image
* Add new version to build workflows