### PR TITLE
fix: move labels to the base dockerfile

### DIFF
--- a/0.29.0/Dockerfile
+++ b/0.29.0/Dockerfile
@@ -1,11 +1,1 @@
 FROM ngalayko/bazel-action:0.29.0
-
-LABEL name="Bazel Action"
-LABEL maintainer="Nikita Galaiko"
-LABEL version="0.29.0"
-LABEL repository="https://github.com/ngalaiko/bazel-action"
-
-LABEL com.github.actions.name="Bazel Action"
-LABEL com.github.actions.description="Run Bazel commands"
-LABEL com.github.actions.icon="box"
-LABEL com.github.actions.color="green"

--- a/1.0.0/Dockerfile
+++ b/1.0.0/Dockerfile
@@ -1,11 +1,1 @@
 FROM ngalayko/bazel-action:1.0.0
-
-LABEL name="Bazel Action"
-LABEL maintainer="Nikita Galaiko"
-LABEL version="1.0.0"
-LABEL repository="https://github.com/ngalaiko/bazel-action"
-
-LABEL com.github.actions.name="Bazel Action"
-LABEL com.github.actions.description="Run Bazel commands"
-LABEL com.github.actions.icon="box"
-LABEL com.github.actions.color="green"

--- a/1.1.0/Dockerfile
+++ b/1.1.0/Dockerfile
@@ -1,11 +1,1 @@
 FROM ngalayko/bazel-action:1.1.0
-
-LABEL name="Bazel Action"
-LABEL maintainer="Nikita Galaiko"
-LABEL version="1.1.0"
-LABEL repository="https://github.com/ngalaiko/bazel-action"
-
-LABEL com.github.actions.name="Bazel Action"
-LABEL com.github.actions.description="Run Bazel commands"
-LABEL com.github.actions.icon="box"
-LABEL com.github.actions.color="green"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,16 @@ FROM openjdk:11
 
 ARG BAZEL_VERSION=1.1.0
 
+LABEL name="Bazel Action"
+LABEL maintainer="Nikita Galaiko"
+LABEL version=$BAZEL_VERSION
+LABEL repository="https://github.com/ngalaiko/bazel-action"
+
+LABEL com.github.actions.name="Bazel Action"
+LABEL com.github.actions.description="Run Bazel commands"
+LABEL com.github.actions.icon="box"
+LABEL com.github.actions.color="green"
+
 RUN apt-get update && apt-get install -y \
         g++ \
         zlib1g-dev \


### PR DESCRIPTION
GitHub marketplace fetches information about action from the base `Dockerfile`. Moving labels there to display actual version in the marketplace.