### PR TITLE
Added an working_directory option to `with` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ jobs:
         args: build //...
 ```
 
+## `with` Arguments
+
+Additional context can be passed to the bazel action with the [`with`](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith)
+field. The following fields are supported:
+
+| `with` field | Description |
+| ------------- | ------------- |
+| `working_dir` | Sets the directory that bazel will run in. |
+
 ## bazel version
 
 In order to speed up builds, `ngalaiko/bazel-action/<version>@<tag>` uses prebuilt images with installed bazel 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env sh
 
+WORKING_DIRECTORY="${INPUT_WORKING_DIRECTORY:-./}"
+cd "${WORKING_DIRECTORY}";
+
 bazel "$@"


### PR DESCRIPTION
Added an working_directory option to `with` field in order to run from an arbitrary directory. Bazel can only run from a directory/subdirectory with a workspace, thus as is, projects where WORKSPACE is not in the root of the repository will fail. Another option would be to `touch` a blank WORKSPACE and use the `--package-path` flag with bazel, but this seems like more of a hack.

`working-directory` is consistent with actions, however the environmental variable `INPUT_WORKING-DIRECTORY` is invalid and not passed to the container.