### PR TITLE
add support for bazel 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         - 0.29.0
         - 1.0.0
         - 1.1.0
+        - 1.2.0
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,7 @@ jobs:
         - 0.29.0
         - 1.0.0
         - 1.1.0
+        - 1.2.0
 
     steps:
     - uses: actions/checkout@v1

--- a/1.2.0/Dockerfile
+++ b/1.2.0/Dockerfile
@@ -1,0 +1,1 @@
+FROM ngalayko/bazel-action:1.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11
 
-ARG BAZEL_VERSION=1.1.0
+ARG BAZEL_VERSION=1.2.0
 
 RUN apt-get update && apt-get install -y \
         g++ \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: run
-      uses: ngalaiko/bazel-action/1.1.0@master
+      uses: ngalaiko/bazel-action/1.2.0@master
       with:
         args: build //...
 ```
@@ -35,13 +35,13 @@ field. The following fields are supported:
 
 ## bazel version
 
-In order to speed up builds, `ngalaiko/bazel-action/<version>@<tag>` uses prebuilt images with installed bazel 
+In order to speed up builds, `ngalaiko/bazel-action/<version>@<tag>` uses prebuilt images with installed bazel
 and all dependencies. Images are stored in the [DockerHub](https://cloud.docker.com/u/ngalayko/repository/docker/ngalayko/bazel-action).
 
 If you need a specific bazel version, you can import it by changeing `uses` import path. For example:
 
 ```yaml
-uses: ngalaiko/bazel-action/1.1.0@master
+uses: ngalaiko/bazel-action/1.2.0@master
 ```
 
 or


### PR DESCRIPTION
[Bazel 1.2.0](https://github.com/bazelbuild/bazel/releases/tag/1.2.0) has been released.