### PR TITLE
feat: add support for Bazel 1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         - 1.0.0
         - 1.1.0
         - 1.2.0
+        - 1.2.1
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,7 @@ jobs:
         - 1.0.0
         - 1.1.0
         - 1.2.0
+        - 1.2.1
 
     steps:
     - uses: actions/checkout@v1

--- a/1.2.1/Dockerfile
+++ b/1.2.1/Dockerfile
@@ -1,0 +1,1 @@
+FROM ngalayko/bazel-action:1.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11
 
-ARG BAZEL_VERSION=1.2.0
+ARG BAZEL_VERSION=1.2.1
 
 RUN apt-get update && apt-get install -y \
         g++ \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@master
 
     - name: run
-      uses: ngalaiko/bazel-action/1.2.0@master
+      uses: ngalaiko/bazel-action/1.2.1@master
       with:
         args: build //...
 ```
@@ -41,7 +41,7 @@ and all dependencies. Images are stored in the [DockerHub](https://cloud.docker.
 If you need a specific bazel version, you can import it by changeing `uses` import path. For example:
 
 ```yaml
-uses: ngalaiko/bazel-action/1.2.0@master
+uses: ngalaiko/bazel-action/1.2.1@master
 ```
 
 or


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/releases/tag/1.2.1

This is mostly relevant for MacOS builds, which are not currently supported by this Action, but it's nice to be thorough with version support.