### PR TITLE
Installing both python2 and python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y \
         zlib1g-dev \
         bash-completion \
         patch \
-        python3 \
+        python3-dev \
+        python-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -ex; \


### PR DESCRIPTION
According to https://github.com/grpc/grpc/blob/master/third_party/py/python_configure.bzl#L369. We need both versions installed in order to run the builds.