### PR TITLE
Remove Quotes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@
 WORKING_DIRECTORY="${INPUT_WORKING_DIRECTORY:-./}"
 cd "${WORKING_DIRECTORY}";
 
-bazel "$@"
+bazel $@


### PR DESCRIPTION
The quotes broke the Bazel command for me when using `args: test //...`. This PR fixes it.